### PR TITLE
Updated the runtime to 1.0.12

### DIFF
--- a/handlebars.runtime.js
+++ b/handlebars.runtime.js
@@ -20,23 +20,23 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
+@license
 */
 
 // lib/handlebars/browser-prefix.js
-var Handlebars = {};
-module.exports = Handlebars;
-
-(function(Handlebars, undefined) {
+(function(undefined) {
+  var Handlebars = {};
 ;
 // lib/handlebars/base.js
 
-Handlebars.VERSION = "1.0.0-rc.4";
-Handlebars.COMPILER_REVISION = 3;
+Handlebars.VERSION = "1.0.0";
+Handlebars.COMPILER_REVISION = 4;
 
 Handlebars.REVISION_CHANGES = {
   1: '<= 1.0.rc.2', // 1.0.rc.2 is actually rev2 but doesn't report it
   2: '== 1.0.0-rc.3',
-  3: '>= 1.0.0-rc.4'
+  3: '== 1.0.0-rc.4',
+  4: '>= 1.0.0'
 };
 
 Handlebars.helpers  = {};
@@ -68,7 +68,7 @@ Handlebars.registerHelper('helperMissing', function(arg) {
   if(arguments.length === 2) {
     return undefined;
   } else {
-    throw new Error("Could not find property '" + arg + "'");
+    throw new Error("Missing helper: '" + arg + "'");
   }
 });
 
@@ -125,6 +125,9 @@ Handlebars.registerHelper('each', function(context, options) {
   var fn = options.fn, inverse = options.inverse;
   var i = 0, ret = "", data;
 
+  var type = toString.call(context);
+  if(type === functionType) { context = context.call(this); }
+
   if (options.data) {
     data = Handlebars.createFrame(options.data);
   }
@@ -153,22 +156,25 @@ Handlebars.registerHelper('each', function(context, options) {
   return ret;
 });
 
-Handlebars.registerHelper('if', function(context, options) {
-  var type = toString.call(context);
-  if(type === functionType) { context = context.call(this); }
+Handlebars.registerHelper('if', function(conditional, options) {
+  var type = toString.call(conditional);
+  if(type === functionType) { conditional = conditional.call(this); }
 
-  if(!context || Handlebars.Utils.isEmpty(context)) {
+  if(!conditional || Handlebars.Utils.isEmpty(conditional)) {
     return options.inverse(this);
   } else {
     return options.fn(this);
   }
 });
 
-Handlebars.registerHelper('unless', function(context, options) {
-  return Handlebars.helpers['if'].call(this, context, {fn: options.inverse, inverse: options.fn});
+Handlebars.registerHelper('unless', function(conditional, options) {
+  return Handlebars.helpers['if'].call(this, conditional, {fn: options.inverse, inverse: options.fn});
 });
 
 Handlebars.registerHelper('with', function(context, options) {
+  var type = toString.call(context);
+  if(type === functionType) { context = context.call(this); }
+
   if (!Handlebars.Utils.isEmpty(context)) return options.fn(context);
 });
 
@@ -270,6 +276,16 @@ Handlebars.VM = {
         }
         return programWrapper;
       },
+      merge: function(param, common) {
+        var ret = param || common;
+
+        if (param && common) {
+          ret = {};
+          Handlebars.Utils.extend(ret, common);
+          Handlebars.Utils.extend(ret, param);
+        }
+        return ret;
+      },
       programWithDepth: Handlebars.VM.programWithDepth,
       noop: Handlebars.VM.noop,
       compilerInfo: null
@@ -342,5 +358,17 @@ Handlebars.VM = {
 Handlebars.template = Handlebars.VM.template;
 ;
 // lib/handlebars/browser-suffix.js
-})(Handlebars);
+  if (typeof module === 'object' && module.exports) {
+    // CommonJS
+    module.exports = Handlebars;
+
+  } else if (typeof define === "function" && define.amd) {
+    // AMD modules
+    define(function() { return Handlebars; });
+
+  } else {
+    // other, i.e. browser
+    this.Handlebars = Handlebars;
+  }
+}).call(this);
 ;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "handlebars-runtime",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Handlebars runtime only",
   "main": "handlebars.runtime.js",
   "repository": {


### PR DESCRIPTION
Hope it's ok to open a PR instead of an Issue, let me know if not.

Handlebars just released a [new version](https://github.com/wycats/handlebars.js/commit/2a073e0993b40b81fbef82f681bb1dd171f2233b), which has some changes that brake [hbsfy](https://npmjs.org/package/hbsfy).

Handlebars@1.0.12 is incompatible with 1.0.11 runtime (handlebars-runtime@1.0.1), which will be the versions picked when installing hbsfy ([package.json](https://github.com/epeli/node-hbsfy/blob/master/package.json#L25))
